### PR TITLE
chore(deps): mark `@typescript-eslint/utils` as dependency

### DIFF
--- a/.changeset/twelve-keys-yawn.md
+++ b/.changeset/twelve-keys-yawn.md
@@ -1,0 +1,5 @@
+---
+"@sushichan044/eslint-config-array-resolver": patch
+---
+
+chore(deps): mark `@typescript-eslint/utils` as dependency

--- a/packages/eslint-config-array-resolver/package.json
+++ b/packages/eslint-config-array-resolver/package.json
@@ -42,7 +42,6 @@
     "@arethetypeswrong/cli": "catalog:build",
     "@biomejs/biome": "catalog:biome",
     "@types/node": "24.1.0",
-    "@typescript-eslint/utils": "8.38.0",
     "@virtual-live-lab/eslint-config": "catalog:eslint",
     "@virtual-live-lab/tsconfig": "catalog:typescript",
     "eslint": "catalog:eslint",
@@ -55,6 +54,7 @@
     "vitest": "catalog:test"
   },
   "dependencies": {
+    "@typescript-eslint/utils": "^8.0.0",
     "bundle-require": "^5.1.0",
     "empathic": "^2.0.0",
     "mlly": "^1.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
 
   packages/eslint-config-array-resolver:
     dependencies:
+      '@typescript-eslint/utils':
+        specifier: ^8.0.0
+        version: 8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3)
       bundle-require:
         specifier: ^5.1.0
         version: 5.1.0(esbuild@0.25.8)
@@ -106,9 +109,6 @@ importers:
       '@types/node':
         specifier: 24.1.0
         version: 24.1.0
-      '@typescript-eslint/utils':
-        specifier: 8.38.0
-        version: 8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3)
       '@virtual-live-lab/eslint-config':
         specifier: catalog:eslint
         version: 2.2.24(@typescript-eslint/parser@8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.5.1))(tailwindcss@3.4.17)(typescript@5.8.3)


### PR DESCRIPTION
`@typescript-eslint/utils` is used as base type of exported type, so it must be marked as dependency.